### PR TITLE
#20 - Modification du taux d'évolution du recule

### DIFF
--- a/src/test/java/fr/indigeo/wps/clt/TestWPS.java
+++ b/src/test/java/fr/indigeo/wps/clt/TestWPS.java
@@ -28,7 +28,7 @@ public class TestWPS {
 		try {
 			FeatureCollection<SimpleFeatureType, SimpleFeature> refLineFc = getFeatureCollections(refLineFile);
 			FeatureCollection<SimpleFeatureType, SimpleFeature> drawRadialsFc = getRadialsTest(refLineFc, 50, 20,
-					true);
+					false);
 			getGeoJsonFile(drawRadialsFc, dataDir, "drawRadialsFc");
 			FeatureCollection<SimpleFeatureType, SimpleFeature> coastLines = getFeatureCollections(coastLinesFile);
 			
@@ -61,7 +61,7 @@ public class TestWPS {
 		try {
 			// draw radials Test
 			FeatureCollection<SimpleFeatureType, SimpleFeature> refLineFc = getFeatureCollections(refLineFile);
-			FeatureCollection<SimpleFeatureType, SimpleFeature> drawRadialsFc = getRadialsTest(refLineFc, 100, 50, true);
+			FeatureCollection<SimpleFeatureType, SimpleFeature> drawRadialsFc = getRadialsTest(refLineFc, 50, 20, false);
 			getGeoJsonFile(drawRadialsFc, dataDir, "drawRadialsFc");
 			LOGGER.info("drawRadialsFc.json est généré dans le dossier data de votre projet ! vous pouvez le visualiser maintenant.");
 


### PR DESCRIPTION
Ref #20 

Cette Pr : 
- contient 2 nouvelles valeurs pour l'évolution globale de la distance entre deux années, et l'évolution moyenne par an de la distance entre 2 années
- contient un correctif pour ajouter un signe positif ou négatif à la distance de tdc qui sépare 2 dates afin d'avoir un taux d'évolution positif ou négatif
- Corrige la direction par défaut pour le test mvn getDistance