### PR TITLE
TDC - les radiales doivent intersecter le TDC de date de référence

### DIFF
--- a/src/main/java/fr/indigeo/wps/clt/CoastLinesTrackingWPS.java
+++ b/src/main/java/fr/indigeo/wps/clt/CoastLinesTrackingWPS.java
@@ -191,7 +191,7 @@ public class CoastLinesTrackingWPS extends StaticMethodsProcessFactory<CoastLine
 				Point dateRefPoint = null;
 				double previousDist = 0;
 				for (Map.Entry<Date[], LineString> dateLine : radialLines.getValue().entrySet()) {
-										LOGGER.debug("Traitement de l'id : " + id);
+					LOGGER.debug("Traitement de l'id : " + id);
 					double distFromStart = 0;
 					// point de fin de la ligne
 					Point endPoint = dateLine.getValue().getEndPoint();

--- a/src/main/java/fr/indigeo/wps/clt/CoastLinesTrackingWPS.java
+++ b/src/main/java/fr/indigeo/wps/clt/CoastLinesTrackingWPS.java
@@ -165,7 +165,7 @@ public class CoastLinesTrackingWPS extends StaticMethodsProcessFactory<CoastLine
 			// calcul de tous les points d'intersection entre geom radiales et geom trait de côte
 			Map<String, Map<Date, Point>> intersectedPoints = WPSUtils.getIntersectedPoints(radialsMap, coastLinesMap);
 			// 
-			Map<String, Map<Date[], LineString>> RadialesDatesLines = WPSUtils.getComposedSegment(intersectedPoints);
+			Map<String, Map<Date[], LineString>> RadialesDatesLines = WPSUtils.getComposedSegment(intersectedPoints, minDateRef.get());
 			resultFeatureCollection = new DefaultFeatureCollection(null, simpleFeatureBuilder.getFeatureType());
 			int id = 0;
 			// on parcours les radiales une par une
@@ -191,7 +191,7 @@ public class CoastLinesTrackingWPS extends StaticMethodsProcessFactory<CoastLine
 				Point dateRefPoint = null;
 				double previousDist = 0;
 				for (Map.Entry<Date[], LineString> dateLine : radialLines.getValue().entrySet()) {
-					LOGGER.debug("Traitement de l'id : " + id);
+										LOGGER.debug("Traitement de l'id : " + id);
 					double distFromStart = 0;
 					// point de fin de la ligne
 					Point endPoint = dateLine.getValue().getEndPoint();
@@ -245,7 +245,7 @@ public class CoastLinesTrackingWPS extends StaticMethodsProcessFactory<CoastLine
 					int nbrJoursFromDateRef = WPSUtils.getNbrDaysBetweenTwoDate(minDateRef.get(),
 							dateLine.getKey()[1]);
 					double nbYears = nbrJoursFromDateRef / 365;
-					double taux = distFromDateRef/nbYears;
+					double taux = distFromDateRef / nbYears;
 					// Taux entre les deux années de la ligne
 					double evolBetween = (distFromStart / nbrJours) * 365;
 

--- a/src/main/java/fr/indigeo/wps/clt/utils/WPSUtils.java
+++ b/src/main/java/fr/indigeo/wps/clt/utils/WPSUtils.java
@@ -400,7 +400,6 @@ public class WPSUtils {
 				Geometry intersectPoint = radialGeom.intersection(coastGeom);
 				if (intersectPoint != null) {
 					LOGGER.debug("getIntersectedPoints intersection entre la radial et un trait de cote");
-					LOGGER.debug("getIntersectedPoints coastline " + coastLine.getKey() + "-" + coastLine.getValue());
 					// Ajout le point d'intersection avec la date comme clé
 					if (intersectPoint.getGeometryType() == Geometry.TYPENAME_POINT) {
 						intersectPoints.put(coastLine.getKey(), (Point) intersectPoint);
@@ -428,7 +427,7 @@ public class WPSUtils {
 	 * @return
 	 */
 	public static Map<String, Map<Date[], LineString>> getComposedSegment(
-			Map<String, Map<Date, Point>> intersectedPoints) {
+			Map<String, Map<Date, Point>> intersectedPoints, Date dateRef) {
 
 		GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 2154);
 		Map<String, Map<Date[], LineString>> radialLinesByDates = new HashMap<String, Map<Date[], LineString>>();
@@ -442,6 +441,11 @@ public class WPSUtils {
 				List<Date> DateList = new ArrayList<Date>(intersectedPointOnradial.getValue().keySet());
 				LOGGER.debug("getComposedSegment keyList size " + DateList.size());
 
+				// on ne va traiter que les radiales qui intersectent la date de référence
+				// sinon il ne sera pas possible de comparer les TDC à la date de référence
+				if (!DateList.contains(dateRef)) {
+					continue;
+				}
 				for (int i = 0; i < DateList.size() - 1; i++) {
 					Coordinate[] coordinates = new Coordinate[2];
 					Date[] formToCoastLinesDate = new Date[2];


### PR DESCRIPTION
> ref https://github.com/LETG/coastlinetracking/issues/24

Les distances et les taux de recul du trait de côte étant dépendant de la date de référence, le calcule ne doit pas traiter les radiales qui ne sont pas intersectées par la date de référence.

Cette PR permet de prendre en compte ce point.